### PR TITLE
Fix typo in buttons documentation

### DIFF
--- a/docs/css/components/buttons.md
+++ b/docs/css/components/buttons.md
@@ -97,7 +97,7 @@ Button primary, button secondary and button tertiary also exist in a "masquerade
 
 ## Button disabled state
 
-All buttons can have a disabled state by adding the attribute *disabled="disabled"*.
+All buttons can have a disabled state by adding the attribute `disabled="disabled"`.
 
 <button class="button button--primary" disabled="disabled">
     <span class="button__label">Primary button</span>
@@ -127,11 +127,11 @@ All buttons can have a disabled state by adding the attribute *disabled="disable
 </button>
 ```
 
-If you need to use the disabled state on an ```<a>``` element, keep in mind that it behaves a bit differently than a ```<button>```:
+If you need to use the disabled state on a ```<a>``` element, keep in mind that it behaves a bit differently than a ```<button>```:
 
 ::: warning
 * `<a>` don’t support the disabled attribute, so you must add the `.button-disabled` class to make it visually appear disabled.
-* Disabled buttons link should include the `aria-disabled="true"` attribute to indicate the state of the element to accessibility devices. Eventually a `tabindex=-'1'`could be add.
+* Disabled buttons link should include the `aria-disabled="true"` attribute to indicate the state of the element to accessibility devices. Eventually a `tabindex="-1"`could be added.
 :::
 
 <a href="" class="button button--primary button-disabled" aria-disabled="true" tabindex="-1" role="button">

--- a/docs/css/components/buttons.md
+++ b/docs/css/components/buttons.md
@@ -127,7 +127,7 @@ All buttons can have a disabled state by adding the attribute `disabled="disable
 </button>
 ```
 
-If you need to use the disabled state on a ```<a>``` element, keep in mind that it behaves a bit differently than a ```<button>```:
+If you need to use the disabled state on an ```<a>``` element, keep in mind that it behaves a bit differently than a ```<button>```:
 
 ::: warning
 * `<a>` don’t support the disabled attribute, so you must add the `.button-disabled` class to make it visually appear disabled.


### PR DESCRIPTION
I was looking for the doc of disabled links, and this part of the doc was very helpful. 👌

This PR fix minor typos in this area.