### PR TITLE
Fix license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "git+https://github.com/axel-springer-kugawana/iwb_serenity.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/axel-springer-kugawana/iwb_serenity/issues"
   },


### PR DESCRIPTION
For some reason, the `license` field doesn’t reflect the content of the [`LICENSE`](https://github.com/axel-springer-kugawana/iwb_serenity/blob/master/LICENSE).

(Both ISC and MIT are roughly the same with different wordings.)