### PR TITLE
Fixed Deprecation Warning for Using / for division outside of calc()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.2 - 2024-04-16
+
+### Changes
+
+- Improved library reliability by fixing local development warnings
+
 ## 3.1.1 - 2024-02-20
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iwb_serenity",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Immoweb Front-end Framework",
   "main": "dist/js/serenity.min.js",
   "unpkg": "dist/js/serenity.min.js",

--- a/src/scss/utils/_variables.scss
+++ b/src/scss/utils/_variables.scss
@@ -125,9 +125,9 @@ $columns-amount: 12 !default;
 $gutter: 1.25rem !default;
 
 $max-column-width-small: calc(($max-width-small - ($gutter * $columns-amount)) / $columns-amount);
-$max-column-width-medium: ($max-width-medium - ($gutter * $columns-amount)) / $columns-amount;
-$max-column-width-desktop: ($max-width-desktop - ($gutter * $columns-amount)) / $columns-amount;
-$max-column-width-widescreen: ($max-width-widescreen - ($gutter * $columns-amount)) / $columns-amount;
+$max-column-width-medium: calc(($max-width-medium - ($gutter * $columns-amount)) / $columns-amount);
+$max-column-width-desktop: calc(($max-width-desktop - ($gutter * $columns-amount)) / $columns-amount);
+$max-column-width-widescreen: calc(($max-width-widescreen - ($gutter * $columns-amount)) / $columns-amount);
 
 // Transition
 // ---------------------


### PR DESCRIPTION
Fixes:
While doing local development (on [iwb-pro-management](https://github.com/axel-springer-kugawana/iwb_pro_management)) we always get the following warning in the console and I fixed it.

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
Recommendation: math.div($max-width-medium - ($gutter * $columns-amount), $columns-amount) or calc(($max-width-medium - ($gutter * $columns-amount)) / $columns-amount)
```
More info: https://sass-lang.com/d/slash-div

<img width="882" alt="Screenshot 2024-04-15 at 11 27 11" src="https://github.com/axel-springer-kugawana/iwb_serenity/assets/121854676/d6e4526e-7b99-4dda-8c45-c367474347c1">

